### PR TITLE
Hopefully fix crashes when tabbing out and back in

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,10 +4,6 @@
 
     <queries>
         <package android:name="com.robtopx.geometryjump" />
-        <intent>
-            <action android:name="android.intent.action.OPEN_DOCUMENT" />
-            <category android:name="android.intent.category.OPENABLE" />
-        </intent>
     </queries>
 
     <uses-permission android:name="android.permission.INTERNET" />
@@ -17,6 +13,7 @@
         android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />

--- a/app/src/main/java/com/geode/launcher/GeometryDashActivity.kt
+++ b/app/src/main/java/com/geode/launcher/GeometryDashActivity.kt
@@ -336,14 +336,19 @@ class GeometryDashActivity : AppCompatActivity(), Cocos2dxHelper.Cocos2dxHelperL
         }
     }
 
+    override fun onRestart() {
+        super.onRestart()
+        mIsOnPause = false
+        BaseRobTopActivity.isPaused = false
+        if (!this.mIsRunning) {
+            resumeGame()
+        }
+    }
+
     override fun onPause() {
         super.onPause()
         mIsOnPause = true
         BaseRobTopActivity.isPaused = true
-    }
-
-    override fun onStop() {
-        super.onStop()
         if (mIsRunning) {
             pauseGame()
         }

--- a/app/src/main/java/com/geode/launcher/activityresult/GeodeOpenFileActivityResult.kt
+++ b/app/src/main/java/com/geode/launcher/activityresult/GeodeOpenFileActivityResult.kt
@@ -12,6 +12,8 @@ open class GeodeOpenFileActivityResult : ActivityResultContract<GeodeOpenFileAct
     class OpenFileParams(val extraMimes: Array<String>, val defaultPath: Uri?) {}
     override fun createIntent(context: Context, input: OpenFileParams): Intent {
         val intent = Intent(Intent.ACTION_OPEN_DOCUMENT)
+            .addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+            .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
             .putExtra(Intent.EXTRA_MIME_TYPES, input.extraMimes)
             .setType("*/*")
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/app/src/main/java/com/geode/launcher/activityresult/GeodeOpenFilesActivityResult.kt
+++ b/app/src/main/java/com/geode/launcher/activityresult/GeodeOpenFilesActivityResult.kt
@@ -13,6 +13,8 @@ open class GeodeOpenFilesActivityResult : ActivityResultContract<GeodeOpenFilesA
     override fun createIntent(context: Context, input: OpenFileParams): Intent {
         val intent = Intent(Intent.ACTION_OPEN_DOCUMENT)
             .putExtra(Intent.EXTRA_MIME_TYPES, input.extraMimes)
+            .addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+            .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
             .putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
             .setType("*/*")
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/app/src/main/java/com/geode/launcher/activityresult/GeodeSaveFileActivityResult.kt
+++ b/app/src/main/java/com/geode/launcher/activityresult/GeodeSaveFileActivityResult.kt
@@ -12,6 +12,7 @@ open class GeodeSaveFileActivityResult : ActivityResultContract<GeodeSaveFileAct
     class SaveFileParams(val mimeType: String?, val defaultPath: Uri?) {}
     override fun createIntent(context: Context, input: SaveFileParams): Intent {
         val intent = Intent(Intent.ACTION_CREATE_DOCUMENT)
+            .addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
             .setType(input.mimeType ?: "*/*")
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             if (input.defaultPath != null) {


### PR DESCRIPTION
So far this seems to be stable on my phone. The fix was moving GLSurfaceView.onPause() to the GD activity onPause, instead of onStop.
It seems that in onStop, the OpenGL context is already gone, so calling GLSurfaceView.onPause there will trigger an error, leading to either crashes or funny behaviour.