### PR TITLE
Add support for requesting permissions from native code

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <uses-feature
         android:name="android.hardware.wifi"

--- a/app/src/main/java/com/geode/launcher/GeometryDashActivity.kt
+++ b/app/src/main/java/com/geode/launcher/GeometryDashActivity.kt
@@ -45,10 +45,16 @@ class GeometryDashActivity : AppCompatActivity(), Cocos2dxHelper.Cocos2dxHelperL
     private var mHasWindowFocus = false
     private var mReceiver: BroadcastReceiver? = null
 
+    companion object {
+        var instance: GeometryDashActivity? = null
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         setupUIState()
 
         super.onCreate(savedInstanceState)
+
+        instance = this
 
         // return back to main if Geometry Dash isn't found
         if (!LaunchUtils.isGeometryDashInstalled(packageManager)) {
@@ -313,6 +319,7 @@ class GeometryDashActivity : AppCompatActivity(), Cocos2dxHelper.Cocos2dxHelperL
         super.onDestroy()
         unregisterReceivers()
         FMOD.close()
+        instance = null
     }
 
     private fun resumeGame() {

--- a/app/src/main/java/com/geode/launcher/GeometryDashActivity.kt
+++ b/app/src/main/java/com/geode/launcher/GeometryDashActivity.kt
@@ -45,16 +45,10 @@ class GeometryDashActivity : AppCompatActivity(), Cocos2dxHelper.Cocos2dxHelperL
     private var mHasWindowFocus = false
     private var mReceiver: BroadcastReceiver? = null
 
-    companion object {
-        var instance: GeometryDashActivity? = null
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         setupUIState()
 
         super.onCreate(savedInstanceState)
-
-        instance = this
 
         // return back to main if Geometry Dash isn't found
         if (!LaunchUtils.isGeometryDashInstalled(packageManager)) {
@@ -319,7 +313,6 @@ class GeometryDashActivity : AppCompatActivity(), Cocos2dxHelper.Cocos2dxHelperL
         super.onDestroy()
         unregisterReceivers()
         FMOD.close()
-        instance = null
     }
 
     private fun resumeGame() {

--- a/app/src/main/java/com/geode/launcher/utils/GeodeUtils.kt
+++ b/app/src/main/java/com/geode/launcher/utils/GeodeUtils.kt
@@ -265,22 +265,23 @@ object GeodeUtils {
     }
 
     @JvmStatic
-    fun requestPermission(permission: String): Boolean {
+    fun requestPermission(permission: String) {
         if (getPermissionStatus(permission)) {
             permissionCallback(true)
-            return true
+            return
         }
 
         activity.get()?.run {
             try {
                 requestPermissionLauncher.launch(permission)
-                return true
             } catch (e: ActivityNotFoundException) {
-                return false
+                permissionCallback(false)
             }
+
+            return
         }
 
-        return false
+        permissionCallback(false)
     }
 
     @Suppress("KotlinJniMissingFunction")

--- a/app/src/main/java/com/geode/launcher/utils/GeodeUtils.kt
+++ b/app/src/main/java/com/geode/launcher/utils/GeodeUtils.kt
@@ -12,10 +12,8 @@ import android.util.Log
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.documentfile.provider.DocumentFile
-import com.geode.launcher.GeometryDashActivity
 import com.geode.launcher.activityresult.GeodeOpenFileActivityResult
 import com.geode.launcher.activityresult.GeodeOpenFilesActivityResult
 import com.geode.launcher.activityresult.GeodeSaveFileActivityResult

--- a/app/src/main/java/com/geode/launcher/utils/GeodeUtils.kt
+++ b/app/src/main/java/com/geode/launcher/utils/GeodeUtils.kt
@@ -5,13 +5,17 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.provider.DocumentsContract
 import android.util.Log
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.documentfile.provider.DocumentFile
+import com.geode.launcher.GeometryDashActivity
 import com.geode.launcher.activityresult.GeodeOpenFileActivityResult
 import com.geode.launcher.activityresult.GeodeOpenFilesActivityResult
 import com.geode.launcher.activityresult.GeodeSaveFileActivityResult
@@ -248,5 +252,24 @@ object GeodeUtils {
 
     fun isGeodeUri(uri: Uri): Boolean {
         return "com.geode.launcher.user" == uri.authority
+    }
+
+    @JvmStatic
+    fun getPermissionStatus(permission: String): Boolean {
+        return ContextCompat.checkSelfPermission(
+            GeometryDashActivity.instance?.applicationContext ?: return false,
+            permission
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    @JvmStatic
+    fun requestPermission(permission: String) {
+        if (!getPermissionStatus(permission)) {
+            ActivityCompat.requestPermissions(
+                GeometryDashActivity.instance!!,
+                arrayOf(permission),
+                12345
+            )
+        }
     }
 }


### PR DESCRIPTION
This adds the methods `requestPermission` and `getPermissionStatus`, allowing mods (or Geode itself) to know if a certain permission is granted to the app, or request it to be if it isn't.