### PR TITLE
Setting to disable fullscreen keyboard

### DIFF
--- a/app/src/main/java/com/geode/launcher/GeometryDashActivity.kt
+++ b/app/src/main/java/com/geode/launcher/GeometryDashActivity.kt
@@ -14,6 +14,7 @@ import android.util.Log
 import android.view.ViewGroup
 import android.view.WindowInsets
 import android.view.WindowManager
+import android.view.inputmethod.EditorInfo
 import android.widget.FrameLayout
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AlertDialog
@@ -475,6 +476,10 @@ class GeometryDashActivity : AppCompatActivity(), Cocos2dxHelper.Cocos2dxHelperL
         }
 
         editText.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
+        if (!PreferenceUtils.get(application).getBoolean(PreferenceUtils.Key.FULLSCREEN_KEYBOARD)) {
+            editText.imeOptions = editText.imeOptions or EditorInfo.IME_FLAG_NO_FULLSCREEN
+        }
+
         glSurfaceView.cocos2dxEditText = editText
 
         return frameLayout

--- a/app/src/main/java/com/geode/launcher/preferences/SettingsActivity.kt
+++ b/app/src/main/java/com/geode/launcher/preferences/SettingsActivity.kt
@@ -479,6 +479,11 @@ fun GameplaySettingsGroup() {
             maxFrameRate = maxFrameRate
         )
 
+        SettingsCard(
+            title = stringResource(R.string.preference_fullscreen_keyboard_name),
+            preferenceKey = PreferenceUtils.Key.FULLSCREEN_KEYBOARD
+        )
+
         var showSafeModeDialog by remember { mutableStateOf(false) }
 
         OptionsButton(

--- a/app/src/main/java/com/geode/launcher/utils/PreferenceUtils.kt
+++ b/app/src/main/java/com/geode/launcher/utils/PreferenceUtils.kt
@@ -149,12 +149,14 @@ class PreferenceUtils(private val sharedPreferences: SharedPreferences) {
         LAST_UPDATE_CHECK_TIME,
         LAST_LAUNCHER_UPDATE,
         DISABLE_UPDATE_CACHE,
+        FULLSCREEN_KEYBOARD,
     }
 
     private fun defaultValueForBooleanKey(key: Key): Boolean {
         return when (key) {
             Key.UPDATE_AUTOMATICALLY -> true
             Key.DEVELOPER_MODE -> BuildConfig.DEBUG
+            Key.FULLSCREEN_KEYBOARD -> true
             else -> false
         }
     }
@@ -199,6 +201,7 @@ class PreferenceUtils(private val sharedPreferences: SharedPreferences) {
             Key.LAST_UPDATE_CHECK_TIME -> "PreferenceLastUpdateCheckTime"
             Key.LAST_LAUNCHER_UPDATE -> "PreferenceLastLauncherUpdate"
             Key.DISABLE_UPDATE_CACHE -> "PreferenceDisableUpdateCache"
+            Key.FULLSCREEN_KEYBOARD -> "PreferenceFullscreenKeyboard"
             // Key.RELEASE_CHANNEL -> "PreferenceReleaseChannel"
             // Key.LAST_DISMISSED_UPDATE -> "PreferenceLastDismissedUpdate"
             // Key.FORCE_HRR -> "PreferenceForceHighRefreshRate"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,6 +142,7 @@
     <string name="preference_category_testing">General</string>
     <string name="preference_load_automatically_name">Automatically launch</string>
     <string name="preference_load_automatically_description">Launches the game after a short delay.</string>
+    <string name="preference_fullscreen_keyboard_name">Fullscreen Keyboard</string>
     <string name="preferences_copy_external_button">Copy external files directory</string>
     <string name="preferences_open_file_manager">Open file manager</string>
     <string name="preferences_view_logs">View application logs</string>


### PR DESCRIPTION
android users can finally type 20 character passwords without character limit bypass :speaking_head: 

fullscreen keyboard on
<img width="2370" height="1094" alt="image" src="https://github.com/user-attachments/assets/3208c123-91a4-4087-b78c-f21b96b78716" />

fullscreen keyboard off
<img width="2370" height="1094" alt="image" src="https://github.com/user-attachments/assets/c0fcc41d-b586-45a5-9dee-fd23ece728d6" />
